### PR TITLE
Optional localization for images

### DIFF
--- a/src/export.py
+++ b/src/export.py
@@ -396,7 +396,7 @@ class Export(commands.Cog):
         )
 
         # Poster
-        poster = utils.POSTER_DIR / f"Alice Briarwood {ctx.game.alice}{utils.IMAGE_EXT}"
+        poster = utils.get_image(utils.POSTER_DIR, f"Alice Briarwood {ctx.game.alice}")
         await loop.run_in_executor(
             None, pdf.image,
             *(str(poster), COVER_POSTER_X,
@@ -495,11 +495,11 @@ class Export(commands.Cog):
 
         # Character and motive cards
         name = gamedata.CHARACTERS[character]
-        card = (utils.CHARACTER_IMAGE_DIR / name).with_suffix(utils.IMAGE_EXT)
+        card = utils.get_image(utils.CHARACTER_IMAGE_DIR, name)
         pdf.image(str(card), CHAR_CARD_LEFT, CHAR_CARD_TOP, CHAR_CARD_WIDTH)
 
         motive = ctx.game.motives[character]
-        card = utils.MOTIVE_DIR / (f"Motive {motive}{utils.IMAGE_EXT}")
+        card = utils.get_image(utils.MOTIVE_DIR, f"Motive {motive}")
         pdf.image(str(card), CHAR_CARD_LEFT, MOTIVE_CARD_TOP, CHAR_CARD_WIDTH)
 
         # Clues
@@ -520,17 +520,17 @@ class Export(commands.Cog):
 
             # Clue card
             choice = ctx.game.picked_clues[clue]
-            card = utils.CLUE_DIR / str(clue) / f"{clue}-{choice}{utils.IMAGE_EXT}"
+            card = utils.get_image(utils.CLUE_DIR / str(clue), f"{clue}-{choice}")
             pdf.image(str(card), CLUE_CARD_LEFT, current_y, CLUE_CARD_WIDTH)
 
 
             # Suspect card
             if clue in ctx.game.suspects_drawn:
                 suspect = gamedata.SUSPECTS[ctx.game.suspects_drawn[clue]]
-                card = utils.SUSPECT_IMAGE_DIR / f"{suspect}{utils.IMAGE_EXT}"
+                card = utils.get_image(utils.SUSPECT_IMAGE_DIR, suspect)
             elif clue in ctx.game.locations_drawn:
                 location = gamedata.LOCATIONS[ctx.game.locations_drawn[clue]]
-                card = utils.LOCATION_IMAGE_DIR / f"{location}{utils.IMAGE_EXT}"
+                card = utils.get_image(utils.LOCATION_IMAGE_DIR, location)
 
             pdf.image(str(card), SUSPECT_CARD_LEFT, current_y, CLUE_CARD_WIDTH)
 
@@ -597,7 +597,7 @@ class Export(commands.Cog):
                   CONCLUSION_ROW1_IMAGE_Y, CONCLUSION_CARD_WIDTH)
 
         # Add clue card
-        card = utils.CLUE_DIR / "10" / f"10-{ctx.game.picked_clues[10]}{utils.IMAGE_EXT}"
+        card = utils.get_image(utils.CLUE_DIR / "10", f"10-{ctx.game.picked_clues[10]}")
         pdf.image(str(card), CONCLUSION_CLUE_CARD_X,
                   CONCLUSION_ROW1_IMAGE_Y, CONCLUSION_CARD_WIDTH)
 

--- a/src/game.py
+++ b/src/game.py
@@ -52,9 +52,15 @@ class Game(commands.Cog):
             asyncio.create_task(self.bot.cogs["Manual"].alice(ctx))
 
         # Send characters, suspects, and locations to appropriate channels
-        utils.send_folder(LOCALIZATION_DATA["channels"]["cards"]["character-cards"], utils.CHARACTER_IMAGE_DIR, ctx)
-        utils.send_folder(LOCALIZATION_DATA["channels"]["cards"]["suspect-cards"], utils.SUSPECT_IMAGE_DIR, ctx)
-        utils.send_folder(LOCALIZATION_DATA["channels"]["cards"]["location-cards"], utils.LOCATION_IMAGE_DIR, ctx)
+        utils.send_folder(
+            LOCALIZATION_DATA["channels"]["cards"]["character-cards"], utils.CHARACTER_IMAGE_DIR, ctx
+        )
+        utils.send_folder(
+            LOCALIZATION_DATA["channels"]["cards"]["suspect-cards"], utils.SUSPECT_IMAGE_DIR, ctx
+        )
+        utils.send_folder(
+            LOCALIZATION_DATA["channels"]["cards"]["location-cards"], utils.LOCATION_IMAGE_DIR, ctx
+        )
 
         # Instructions for Charlie Barnes
         channel = ctx.text_channels[LOCALIZATION_DATA["channels"]["clues"]["charlie"]]
@@ -129,7 +135,7 @@ class Game(commands.Cog):
         # Send random 80 minute clue card
         channel = LOCALIZATION_DATA["channels"]["resources"]
         choice = random.randint(1, 3)
-        path = utils.CLUE_DIR / "80" / f"80-{choice}.png"
+        path = utils.get_image(utils.CLUE_DIR / "80", f"80-{choice}")
         utils.send_image(channel, path, ctx)
 
         # Send suspect card
@@ -182,7 +188,7 @@ class Game(commands.Cog):
 
         # 90 minute card/message for Charlie Barnes
         channel = ctx.text_channels[LOCALIZATION_DATA["channels"]["clues"]["charlie"]]
-        await channel.send(file=discord.File(utils.CLUE_DIR / "90/90-1.png"))
+        await channel.send(file=discord.File(utils.get_image(utils.CLUE_DIR, "90/90-1")))
         first_message = LOCALIZATION_DATA["stuff-for-charlie"]["first-message"]
         await channel.send(first_message)
 
@@ -252,7 +258,7 @@ class Game(commands.Cog):
 
                     channel = LOCALIZATION_DATA["channels"]["clues"][ctx.game.ten_char]
                     ending = random.choice(list(i for i in ctx.game.endings if ctx.game.endings[i]))
-                    clue = utils.CLUE_DIR / "10" / f"10-{ending}.png"
+                    clue = utils.get_image(utils.CLUE_DIR / "10", f"10-{ending}")
                     utils.send_image(channel, clue, ctx)
 
                     if ending != 3:
@@ -272,7 +278,7 @@ class Game(commands.Cog):
                     second = random.choice(remaining_suspects)
 
                     # Send to clues channel
-                    path = utils.SUSPECT_IMAGE_DIR / (gamedata.SUSPECTS[second] + ".png")
+                    path = utils.get_image(utils.SUSPECT_IMAGE_DIR, gamedata.SUSPECTS[second])
                     channel = LOCALIZATION_DATA["channels"]["clues"][ctx.game.ten_char]
                     utils.send_image(channel, path, ctx)
 
@@ -339,7 +345,7 @@ class Game(commands.Cog):
         if ctx.game.search_cards:
             search = random.choice(ctx.game.search_cards)
             ctx.game.search_cards.remove(search)
-            image = utils.SEARCHING_DIR / (search + utils.IMAGE_EXT)
+            image = utils.get_image(utils.SEARCHING_DIR, search)
             asyncio.create_task(char_channel.send(file=discord.File(image)))
 
         else:

--- a/src/game.py
+++ b/src/game.py
@@ -188,7 +188,7 @@ class Game(commands.Cog):
 
         # 90 minute card/message for Charlie Barnes
         channel = ctx.text_channels[LOCALIZATION_DATA["channels"]["clues"]["charlie"]]
-        await channel.send(file=discord.File(utils.get_image(utils.CLUE_DIR, "90/90-1")))
+        await channel.send(file=discord.File(utils.get_image(utils.CLUE_DIR / "90", "90-1")))
         first_message = LOCALIZATION_DATA["stuff-for-charlie"]["first-message"]
         await channel.send(first_message)
 

--- a/src/localization.py
+++ b/src/localization.py
@@ -4,6 +4,7 @@ from os import environ
 from pathlib import Path
 # 3rd-party
 from dotenv import dotenv_values
+from resources import LocalizedResource
 
 # White-Rabbit/src/localization.py
 WHITE_RABBIT_DIR = Path(__file__).parent.parent
@@ -26,3 +27,5 @@ localization_file = LOCALIZATION_DIR / LOCALIZATIONS[language_key]
 LOCALIZATION_DATA = None
 with open(localization_file) as f:
     LOCALIZATION_DATA = json.loads(f.read())
+
+LOCALIZATION_RESOURCES = LocalizedResource(language_key)

--- a/src/manual.py
+++ b/src/manual.py
@@ -52,7 +52,7 @@ class Manual(commands.Cog):
 
         ctx.game.alice = choice
 
-        alice = utils.POSTER_DIR / ("Alice Briarwood " + str(ctx.game.alice) + utils.IMAGE_EXT)
+        alice = utils.get_image(utils.POSTER_DIR, f"Alice Briarwood {ctx.game.alice}")
         utils.send_image(LOCALIZATION_DATA["channels"]["resources"], alice, ctx)
 
     @commands.command(
@@ -94,7 +94,7 @@ class Manual(commands.Cog):
             motive = ctx.game.motives[name]
             utils.send_image(
                 channel,
-                utils.MOTIVE_DIR / f"Motive {motive}.png",
+                utils.get_image(utils.MOTIVE_DIR, f"Motive {motive}"),
                 ctx
             )
 
@@ -154,7 +154,7 @@ class Manual(commands.Cog):
         # Send clue card
         channel = utils.get_text_channels(ctx.game.guild)[f"{character}-clues"]
         choice = ctx.game.picked_clues[time]
-        path = utils.CLUE_DIR / str(time) / f"{time}-{choice}.png"
+        path = utils.get_image(utils.CLUE_DIR / str(time), f"{time}-{choice}")
         utils.send_image(channel, path)
 
         # Send suspect/location card to player's clues channel

--- a/src/resources.py
+++ b/src/resources.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Sequence
+
+
+class ImageResource:
+    ALLOWED_EXTENSIONS = ["png", "jpg", "jpeg"]
+
+    def __init__(self, extensions: Sequence[str]) -> None:
+        self.extensions = extensions
+
+    def get(self, directory: Path, name: str) -> Path:
+        for extension in self.extensions:
+            filepath = directory / f"{name}.{extension}"
+            if filepath.exists():
+                return filepath
+
+        raise FileNotFoundError(directory / name)
+
+
+class LocalizedResource:
+    def __init__(self, lang: str) -> None:
+        self.lang = lang
+
+    def get_directory(self, directory: Path) -> Path:
+        localized_dir = directory / self.lang
+
+        if localized_dir.exists():
+            return localized_dir
+
+        return directory
+
+    def get_image(self, directory: Path, name: str) -> Path:
+        img = ImageResource(ImageResource.ALLOWED_EXTENSIONS)
+        try:
+            return img.get(self.get_directory(directory), name)
+        except FileNotFoundError:
+            # Fallback if image does not exists but localized directory exists
+            return img.get(directory, name)
+
+    def get_file(self, directory: Path, filename: str) -> Path:
+        filepath = self.get_directory(directory) / filename
+
+        if filepath.exists():
+            return filepath
+
+        return directory / filename

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,7 @@ import re
 import discord
 # Local
 import gamedata
-from localization import LOCALIZATION_DATA
+from localization import LOCALIZATION_DATA, LOCALIZATION_RESOURCES
 
 # Links
 DOCS_URL = "https://white-rabbit.readthedocs.io/"
@@ -56,21 +56,25 @@ if not os.path.isdir(TEXT_EXPORT_DIR):
     os.mkdir(TEXT_EXPORT_DIR)
 
 
+def get_image(directory: Path, name: str) -> Path:
+    return LOCALIZATION_RESOURCES.get_image(directory, name)
+
+
 # Easy access filepaths
 MASTER_PATHS = {
-    "guide": (PLAYER_RESOURCE_DIR / "Alice is Missing - Guide.jpg"),
-    "character_sheet": (PLAYER_RESOURCE_DIR / "Alice is Missing - Character Sheet.jpg"),
-    "intro": (CARD_DIR / "Misc" / "Introduction.png"),
-    "debrief": (CARD_DIR / "Misc" / "Debrief.png"),
+    "guide": get_image(PLAYER_RESOURCE_DIR, "Alice is Missing - Guide"),
+    "character_sheet": get_image(PLAYER_RESOURCE_DIR, "Alice is Missing - Character Sheet"),
+    "intro": get_image(CARD_DIR / "Misc", "Introduction"),
+    "debrief": get_image(CARD_DIR / "Misc", "Debrief"),
 }
 
-IMAGE_EXT = ".png"
+
 for character in gamedata.CHARACTERS:
-    MASTER_PATHS[character] = (CHARACTER_IMAGE_DIR / gamedata.CHARACTERS[character]).with_suffix(IMAGE_EXT)
+    MASTER_PATHS[character] = get_image(CHARACTER_IMAGE_DIR, gamedata.CHARACTERS[character])
 for suspect in gamedata.SUSPECTS:
-    MASTER_PATHS[suspect] = (SUSPECT_IMAGE_DIR / gamedata.SUSPECTS[suspect]).with_suffix(IMAGE_EXT)
+    MASTER_PATHS[suspect] = get_image(SUSPECT_IMAGE_DIR, gamedata.SUSPECTS[suspect])
 for location in gamedata.LOCATIONS:
-    MASTER_PATHS[location] = (LOCATION_IMAGE_DIR / gamedata.LOCATIONS[location]).with_suffix(IMAGE_EXT)
+    MASTER_PATHS[location] = get_image(LOCATION_IMAGE_DIR, gamedata.LOCATIONS[location])
 
 
 def flip():
@@ -115,8 +119,9 @@ def send_image(channel, filepath, ctx=None):
 def send_folder(channel, path, ctx=None):
     """Sends all images in a folder in alphabetical order"""
 
-    for image in sorted(path.glob("*")):
-        send_image(channel, image, ctx)
+    for image in sorted(path.glob("*.*")):
+        filepath = LOCALIZATION_RESOURCES.get_file(path, image.name)
+        send_image(channel, filepath, ctx)
 
 
 def is_command(message: str):


### PR DESCRIPTION
This allows to localize the images using a subdirectory, as the following:
```
├── Charlie Barnes.png
├── Dakota Travis.png
├── Evan Holwell.png
├── fr
│   ├── Charlie Barnes.png
│   ├── Dakota Travis.png
│   ├── Evan Holwell.png
│   ├── Jack Briarwood.png
│   └── Julia North.png
├── Jack Briarwood.png
└── Julia North.png
```
It uses the `language_key` from the `LANGUAGE` var.
If the subdirectory does not exists _OR_ the image is not available, it will fallback to the original one.

This PR also allows to handle more than 1 image type (png, jpg, jpeg)

_Note:_ In order to have a better localization handling, it would be better to have json files with the resources keys, linked to either the local file path or an hosted url.
URLs makes more sense as it allows to release the network of the additional charge of sending actual image files.