### PR TITLE
Case correction

### DIFF
--- a/src/export.py
+++ b/src/export.py
@@ -169,7 +169,7 @@ PAGE_NUMBER_FONT = WATERMARK_FONTS[1]
 
 
 # Font paths
-FONT_DIR = constants.RESOURCE_DIR / "Fonts"
+FONT_DIR = constants.RESOURCE_DIR / "fonts"
 
 BUILT_DIR = FONT_DIR / "built_titling"
 BUILT_TITLING_RG = BUILT_DIR / "built titling rg.ttf"

--- a/src/export.py
+++ b/src/export.py
@@ -176,7 +176,7 @@ BUILT_TITLING_RG = BUILT_DIR / "built titling rg.ttf"
 BUILT_TITLING_SB = BUILT_DIR / "built titling sb.ttf"
 BUILT_TITLING_BD = BUILT_DIR / "built titling bd.ttf"
 
-ABEL_DIR = FONT_DIR / "Abel"
+ABEL_DIR = FONT_DIR / "abel"
 ABEL_REGULAR = ABEL_DIR / "Abel-Regular.ttf"
 
 


### PR DESCRIPTION
Export was seemingly made impossible because of "Fonts" when the folder is named "fonts"