### PR TITLE
Allow export from older version

### DIFF
--- a/src/debug.py
+++ b/src/debug.py
@@ -20,7 +20,10 @@ class Debug(commands.Cog):
 
         try:
             with open(constants.DEV_ID_FILE) as f:
-                self.dev_ids += [int(line.strip()) for line in f.readlines()]
+                for line in f.readlines():
+                    line = line.strip()
+                    if line:
+                        self.dev_ids.append(int(line))
         except FileNotFoundError:
             # Create file if it doesn't exist
             print("No " + constants.DEV_ID_FILE.name + " found, making empty file")


### PR DESCRIPTION
Tests steps:
- Checkout bot on an older version (< 0.8.0)
- Run a game
- Checkout back the bot to the current version
- Run `!pdf` and check everything is still working

Related to #76
