### PR TITLE
docs: enable "Message Content Intent"

### DIFF
--- a/docs/source/user-guide/installation.rst
+++ b/docs/source/user-guide/installation.rst
@@ -36,7 +36,8 @@ Next, create a new Discord bot as follows:
 - Go to the Bot tab.
 
   - Under "Privileged Gateway Intents", set the toggles for "Server Members
-    Intent" and "Presence Intent" to true and click "Save Changes".
+    Intent", "Presence Intent", and "Message Content Intent" to true and click
+    "Save Changes".
 
 - Go to the OAuth2 tab and scroll to the bottom.
 


### PR DESCRIPTION
Discord introduced this intent recently, and when it is disabled, the bot will not be able to see the contents of messages unless they are DMed or the bot is @-mentioned, which means that normal !-prefixed commands are ignored.

I believe this will fix https://github.com/circumspect/White-Rabbit/issues/111.