### PR TITLE
Fix !upload

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -202,8 +202,6 @@ def ooc_strip(ctx, text: str):
 def upload_file(path):
     """Uploads a file and returns the download URL"""
 
-    url_file = str(TEMP_DIR / "url.txt")
-
-    subprocess.run(["curl", "-T", path, "https://transfer.sh/Alice.pdf", ">", url_file], shell=True)
-    with open(url_file) as f:
-        return f.readline().strip()
+    return subprocess.run(["curl", "-T", path, "https://transfer.sh/Alice.pdf"],
+                          check=True, capture_output=True, text=True
+                          ).stdout.strip()


### PR DESCRIPTION
The previous code was setting `shell=True` to try to use `>` for output redirection, but was still passing a list of arguments. When `shell=True` is set, only a single string is expected for the entire command and all arguments (e.g. `"curl -T in_file https://url  > out_file"`), so subprocess was actually spawning `curl` with no arguments at all. This failure was hidden because the default `check=False` ignores the return code of the spawned process, which is a non-zero value for curl when run with no arguments.

This new code removes the need for a temporary file and instead reads the stdout of the subprocess directly. It also sets `check=True` so that if curl exits with an error, it will manifest as an exception and get reported/logged.

I assume this bug went unnoticed for so long because if the `url.txt` file already exists, the previous `upload_file` implementation would fail to upload the current PDF but still successfully return the existing contents of `url.txt`.

Fixes https://github.com/circumspect/White-Rabbit/issues/113.